### PR TITLE
v1.1.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,18 +2,18 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.6.0
     hooks:
     -   id: trailing-whitespace
     -   id: check-yaml
     -   id: check-added-large-files
     -   id: check-merge-conflict
 -   repo: https://github.com/hhatto/autopep8
-    rev: v2.0.4
+    rev: v2.3.1
     hooks:
     -   id: autopep8
 -   repo: https://github.com/pylint-dev/pylint
-    rev: v3.0.2
+    rev: v3.2.5
     hooks:
     -   id: pylint
 -   repo: https://github.com/pre-commit/mirrors-clang-format

--- a/BUILD.md
+++ b/BUILD.md
@@ -90,9 +90,11 @@ Currently, you need two HydraUSB3 boards connected together via HSPI. You just n
 To be able to access the HydraDancer boards and flash them, root privileges may be required, or you can provide them to your regular user, e.g. with the creation of a file `/etc/udev/rules.d/99-hydrausb3.rules` with
 
 ```
-# UDEV Rules for HydraUSB3 boards, https://github.com/hydrausb3
+# UDEV Rules for HydraUSB3 boards https://github.com/hydrausb3, Hydradancer https://github.com/HydraDancer/hydradancer_fw and Facedancer https://github.com/greatscottgadgets/Facedancer
 # WinChipHead CH569W Bootloader
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="4348", ATTRS{idProduct}=="55e0", MODE="0664", GROUP="plugdev"
+# Hydradancer
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="27d8", MODE="0664", GROUP="plugdev"
 ```
 
 and having your user as member of the group `plugdev`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following examples have been confirmed working:
 
 **DISCLAIMER** : current results for the [highly-stressed stress test of Facedancer](https://github.com/greatscottgadgets/facedancer/blob/main/test/test_stress.py) with 20000 tries.
 
-The current Facedancer stress test results are the following. 
+The current Facedancer stress test results are the following.
 * USB2 High-Speed
   * bulk IN/ctrl IN : pass
   * bulk OUT/ctrl OUT : fails after a few hundred/thousand tries, never reaches 20000
@@ -24,6 +24,8 @@ The current Facedancer stress test results are the following.
 We are currently working on fixing those issues and we have a few culprits in mind :
 * missed interrupts : the main culprit for now, it puts Hydradancer in a blocked state.
 * differences between HS/FS : HS has PING packets which reduces the amount of data transfers for OUT transactions. Since there are no FS examples from WCH and no indications in the datasheet, we experimented to solve this issue.
+
+We implemented a [firmware](https://github.com/hydrausb3/wch-ch56x-lib/tree/main/tests/test_firmware_usb_stress_test) to test the USB2 implementation of `wch-ch56x-lib` with the same stress test and it passes with 100000 tries in both HS and FS. However, Hydradancer's firmware is more complex (more interrupts, USB3 and USB2 at the same time, delays to synchronize with Facedancer).
 
 # Getting started (Hydradancer dongle)
 
@@ -44,7 +46,7 @@ and having your user as member of the group `plugdev`.
 First
 
 ```
-Put the Hydradancer dongle in firmware download mode. For that, you need the following buttons : 
+Put the Hydradancer dongle in firmware download mode. For that, you need the following buttons :
 * reset : button with "RST" next to it
 * flash mode : button with "Flash Mode" next to it
 
@@ -219,7 +221,7 @@ hydradancer/
 |   ├─  firmware_hydradancer # firmware for the Hydradancer dongle
 |   ├─  legacy/ # old HydraUSB3 firmwares, unmaintained
 |   ├─  tests/ # test firmwares to create various USB devices
-|   |   ├─ test_backend # Not up-to-date. Test a Facedancer-like configuration, but without Facedancer. 
+|   |   ├─ test_backend # Not up-to-date. Test a Facedancer-like configuration, but without Facedancer.
 |   |   ├─ native/ # C programs using libusb to interact with the test firmwares
 |   |   ├─ scripts/ # Python scripts using pyusb to interact with the test firmwares
 tools/

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -41,7 +41,7 @@ Different firmwares have been created, along with Python scripts to execute the 
 
 Below are the different test cases and how to test them:
 
-### Backend speedtest
+### (unmaintained) Backend speedtest
 
 * Compile :
   * compile `test_backend/firmware_emulation_board` and `HydraDancer/hydradancer/firmware_control_board` with `make`

--- a/hydradancer/firmware_hydradancer/User/main.c
+++ b/hydradancer/firmware_hydradancer/User/main.c
@@ -102,6 +102,14 @@ int main()
 	usb_device_0.endpoints.tx_complete[5] = usb_emulation_endp5_tx_complete;
 	usb_device_0.endpoints.tx_complete[6] = usb_emulation_endp6_tx_complete;
 	usb_device_0.endpoints.tx_complete[7] = usb_emulation_endp7_tx_complete;
+	usb_device_0.endpoints.tx_complete[8] = usb_emulation_endp7_tx_complete;
+	usb_device_0.endpoints.tx_complete[9] = usb_emulation_endp7_tx_complete;
+	usb_device_0.endpoints.tx_complete[10] = usb_emulation_endp7_tx_complete;
+	usb_device_0.endpoints.tx_complete[11] = usb_emulation_endp7_tx_complete;
+	usb_device_0.endpoints.tx_complete[12] = usb_emulation_endp7_tx_complete;
+	usb_device_0.endpoints.tx_complete[13] = usb_emulation_endp7_tx_complete;
+	usb_device_0.endpoints.tx_complete[14] = usb_emulation_endp7_tx_complete;
+	usb_device_0.endpoints.tx_complete[15] = usb_emulation_endp7_tx_complete;
 	usb_device_0.endpoints.rx_callback[0] = usb_emulation_endp0_rx_callback;
 	usb_device_0.endpoints.rx_callback[1] = usb_emulation_endp1_rx_callback;
 	usb_device_0.endpoints.rx_callback[2] = usb_emulation_endp2_rx_callback;
@@ -110,6 +118,14 @@ int main()
 	usb_device_0.endpoints.rx_callback[5] = usb_emulation_endp5_rx_callback;
 	usb_device_0.endpoints.rx_callback[6] = usb_emulation_endp6_rx_callback;
 	usb_device_0.endpoints.rx_callback[7] = usb_emulation_endp7_rx_callback;
+	usb_device_0.endpoints.rx_callback[8] = usb_emulation_endp7_rx_callback;
+	usb_device_0.endpoints.rx_callback[9] = usb_emulation_endp7_rx_callback;
+	usb_device_0.endpoints.rx_callback[10] = usb_emulation_endp7_rx_callback;
+	usb_device_0.endpoints.rx_callback[11] = usb_emulation_endp7_rx_callback;
+	usb_device_0.endpoints.rx_callback[12] = usb_emulation_endp7_rx_callback;
+	usb_device_0.endpoints.rx_callback[13] = usb_emulation_endp7_rx_callback;
+	usb_device_0.endpoints.rx_callback[14] = usb_emulation_endp7_rx_callback;
+	usb_device_0.endpoints.rx_callback[15] = usb_emulation_endp7_rx_callback;
 	usb_device_0.endpoints.nak_callback = usb_emulation_nak_callback;
 
 	usb2_user_handled.usb2_device_handle_bus_reset = usb_emulation_usb2_device_handle_bus_reset;
@@ -124,7 +140,6 @@ int main()
 	usb_device_set_string_descriptors(&usb_device_0, NULL);
 	// Set the USB device parameters
 	usb2_ep0_passthrough_enabled(true);
-	usb_device_set_endpoint_mask(&usb_device_0, ENDPOINT_1_RX | ENDPOINT_1_TX | ENDPOINT_2_RX | ENDPOINT_2_TX | ENDPOINT_3_RX | ENDPOINT_3_TX | ENDPOINT_4_RX | ENDPOINT_4_TX | ENDPOINT_5_RX | ENDPOINT_5_TX | ENDPOINT_6_RX | ENDPOINT_6_TX | ENDPOINT_7_RX | ENDPOINT_7_TX);
 	usb_emulation_init_endpoints();
 
 	//=================== Finished initializing Emulation device =====================//

--- a/hydradancer/firmware_hydradancer/User/usb_emulation_device.c
+++ b/hydradancer/firmware_hydradancer/User/usb_emulation_device.c
@@ -17,7 +17,6 @@ void usb_emulation_reinit(void)
 	usb_device_set_string_descriptors(&usb_device_0, NULL);
 	// Set the USB device parameters
 	usb2_ep0_passthrough_enabled(true);
-	usb_device_set_endpoint_mask(&usb_device_0, ENDPOINT_1_RX | ENDPOINT_1_TX | ENDPOINT_2_RX | ENDPOINT_2_TX | ENDPOINT_3_RX | ENDPOINT_3_TX | ENDPOINT_4_RX | ENDPOINT_4_TX | ENDPOINT_5_RX | ENDPOINT_5_TX | ENDPOINT_6_RX | ENDPOINT_6_TX | ENDPOINT_7_RX | ENDPOINT_7_TX);
 	usb_emulation_init_endpoints();
 	usb2_setup_endpoints();
 	usb2_set_device_address(0);
@@ -109,26 +108,4 @@ void usb_emulation_init_endpoints(void)
 	usb_device_0.endpoints.tx[7].max_packet_size = USB2_ENDP_1_15_MAX_PACKET_SIZE;
 	usb_device_0.endpoints.tx[7].max_burst = 0;
 	usb_device_0.endpoints.tx[7].max_packet_size_with_burst = USB2_ENDP_1_15_MAX_PACKET_SIZE;
-}
-
-void usb_emulation_do_bus_reset(void)
-{
-	bsp_disable_interrupt();
-	usb_device_set_usb3_device_descriptor(&usb_device_0, NULL);
-	usb_device_set_usb2_device_descriptor(&usb_device_0, NULL);
-	usb_device_set_usb3_config_descriptors(&usb_device_0, NULL);
-	usb_device_set_usb2_config_descriptors(&usb_device_0, NULL);
-	usb_device_set_bos_descriptor(&usb_device_0, NULL);
-	usb_device_set_string_descriptors(&usb_device_0, NULL);
-	usb_device_set_string_descriptors(&usb_device_0, NULL);
-	// Set the USB device parameters
-	usb2_ep0_passthrough_enabled(true);
-	usb_device_set_endpoint_mask(&usb_device_0, ENDPOINT_1_RX | ENDPOINT_1_TX | ENDPOINT_2_RX | ENDPOINT_2_TX | ENDPOINT_3_RX | ENDPOINT_3_TX | ENDPOINT_4_RX | ENDPOINT_4_TX | ENDPOINT_5_RX | ENDPOINT_5_TX | ENDPOINT_6_RX | ENDPOINT_6_TX | ENDPOINT_7_RX | ENDPOINT_7_TX);
-	usb_emulation_init_endpoints();
-	usb2_setup_endpoints();
-	for (int i = 0; i < MAX_ENDPOINTS_SUPPORTED; ++i)
-	{
-		endp_rx_set_state(&usb_device_0, i, ENDP_STATE_ACK);
-	}
-	bsp_enable_interrupt();
 }

--- a/hydradancer/firmware_hydradancer/User/usb_emulation_device.h
+++ b/hydradancer/firmware_hydradancer/User/usb_emulation_device.h
@@ -25,6 +25,4 @@ void usb_emulation_reinit(void);
 
 void usb_emulation_init_endpoints(void);
 
-void usb_emulation_do_bus_reset(void);
-
 #endif

--- a/hydradancer/tests/scripts/test_hspi_serdes.py
+++ b/hydradancer/tests/scripts/test_hspi_serdes.py
@@ -51,8 +51,8 @@ if __name__ == "__main__":
         intf,
         find_all=True,
         # match the first OUT endpoint
-        custom_match=lambda e: \
-        usb.util.endpoint_direction(e.bEndpointAddress) == \
+        custom_match=lambda e:
+        usb.util.endpoint_direction(e.bEndpointAddress) ==
         usb.util.ENDPOINT_IN))
 
     assert ep_in is not None

--- a/hydradancer/tests/scripts/test_loopback.py
+++ b/hydradancer/tests/scripts/test_loopback.py
@@ -79,16 +79,16 @@ if __name__ == "__main__":
         intf,
         find_all=True,
         # match the first OUT endpoint
-        custom_match=lambda e: \
-        usb.util.endpoint_direction(e.bEndpointAddress) == \
+        custom_match=lambda e:
+        usb.util.endpoint_direction(e.bEndpointAddress) ==
         usb.util.ENDPOINT_IN))
 
     ep_out = list(usb.util.find_descriptor(
         intf,
         # match the first OUT endpoint
         find_all=True,
-        custom_match=lambda e: \
-        usb.util.endpoint_direction(e.bEndpointAddress) == \
+        custom_match=lambda e:
+        usb.util.endpoint_direction(e.bEndpointAddress) ==
         usb.util.ENDPOINT_OUT))
 
     assert ep_in is not None

--- a/hydradancer/tests/scripts/test_loopback_randomize_packetsize.py
+++ b/hydradancer/tests/scripts/test_loopback_randomize_packetsize.py
@@ -85,16 +85,16 @@ if __name__ == "__main__":
         intf,
         find_all=True,
         # match the first OUT endpoint
-        custom_match=lambda e: \
-        usb.util.endpoint_direction(e.bEndpointAddress) == \
+        custom_match=lambda e:
+        usb.util.endpoint_direction(e.bEndpointAddress) ==
         usb.util.ENDPOINT_IN))
 
     ep_out = list(usb.util.find_descriptor(
         intf,
         # match the first OUT endpoint
         find_all=True,
-        custom_match=lambda e: \
-        usb.util.endpoint_direction(e.bEndpointAddress) == \
+        custom_match=lambda e:
+        usb.util.endpoint_direction(e.bEndpointAddress) ==
         usb.util.ENDPOINT_OUT))
 
     assert ep_in is not None

--- a/hydradancer/tests/scripts/test_speedtest.py
+++ b/hydradancer/tests/scripts/test_speedtest.py
@@ -61,15 +61,15 @@ if __name__ == "__main__":
     ep_in = usb.util.find_descriptor(
         intf,
         # match the first OUT endpoint
-        custom_match=lambda e: \
-        usb.util.endpoint_direction(e.bEndpointAddress) == \
+        custom_match=lambda e:
+        usb.util.endpoint_direction(e.bEndpointAddress) ==
         usb.util.ENDPOINT_IN)
 
     ep_out = usb.util.find_descriptor(
         intf,
         # match the first OUT endpoint
-        custom_match=lambda e: \
-        usb.util.endpoint_direction(e.bEndpointAddress) == \
+        custom_match=lambda e:
+        usb.util.endpoint_direction(e.bEndpointAddress) ==
         usb.util.ENDPOINT_OUT)
 
     assert ep_in is not None

--- a/hydradancer/tests/scripts/test_speedtest_one_by_one.py
+++ b/hydradancer/tests/scripts/test_speedtest_one_by_one.py
@@ -64,15 +64,15 @@ if __name__ == "__main__":
     ep_in = usb.util.find_descriptor(
         intf,
         # match the first OUT endpoint
-        custom_match=lambda e: \
-        usb.util.endpoint_direction(e.bEndpointAddress) == \
+        custom_match=lambda e:
+        usb.util.endpoint_direction(e.bEndpointAddress) ==
         usb.util.ENDPOINT_IN)
 
     ep_out = usb.util.find_descriptor(
         intf,
         # match the first OUT endpoint
-        custom_match=lambda e: \
-        usb.util.endpoint_direction(e.bEndpointAddress) == \
+        custom_match=lambda e:
+        usb.util.endpoint_direction(e.bEndpointAddress) ==
         usb.util.ENDPOINT_OUT)
 
     assert ep_in is not None


### PR DESCRIPTION
- Added all endpoint numbers from 0 to 15. However, the WCH569 can't use all of them at the same time so there are hard-coded incompatible endpoints.
- Bumped wch-ch56x-lib to v1.1.2.
- Trying to solve issue of missing interrupts.